### PR TITLE
Fix timeLimit condition

### DIFF
--- a/src/RecordingProcessor.js
+++ b/src/RecordingProcessor.js
@@ -440,7 +440,7 @@ function recordingProcessorEncapsulation() {
 
 			// If one is set, check if we have not reached the time limit
 			if ( this.config.timeLimit > 0 ) {
-				if ( this.config.timeLimit >= this._audioSamples.getDuration() ) {
+				if ( this.config.timeLimit <= this._audioSamples.getDuration() ) {
 					this._stop();
 				}
 			}


### PR DESCRIPTION
The condition for `timeLimit` is reversed and thus, setting `timeLimit` to any value other than zero will stop recording immediately right after starting.